### PR TITLE
Allow arrays to be passed as a `class` option

### DIFF
--- a/lib/phosphor_icons/icon.rb
+++ b/lib/phosphor_icons/icon.rb
@@ -17,7 +17,7 @@ module PhosphorIcons
         @width = phosphor_icon["width"]
         @height = phosphor_icon["height"]
         @options = {
-          class: "phosphor-icon #{options[:class]}".strip,
+          class: "phosphor-icon #{extract_class(options[:class])}".strip,
           viewBox: viewbox,
           xmlns: "http://www.w3.org/2000/svg",
           fill: "currentColor",
@@ -43,6 +43,12 @@ module PhosphorIcons
       attrs = ""
       options.each { |attr, value| attrs += "#{attr}=\"#{value}\" " }
       attrs.strip
+    end
+
+    def extract_class(option)
+      return option unless option.is_a? Array
+
+      option.join(' ')
     end
 
     def viewbox

--- a/test/test_phosphor_icons.rb
+++ b/test/test_phosphor_icons.rb
@@ -46,6 +46,11 @@ class TestPhosphorIcons < Minitest::Test
     assert_includes(icon.to_svg, "class=\"phosphor-icon foo\"")
   end
 
+  def test_accepts_an_array_for_classes
+    icon = phosphor_icon(:alarm, class: %w[foo bar])
+    assert_includes(icon.to_svg, 'class="phosphor-icon foo bar"')
+  end
+
   def test_default_height
     icon = phosphor_icon(:alarm)
     assert_equal(24, icon.height)


### PR DESCRIPTION
Rails tag helpers allow users to supply an array of class names to `class`, which will be joined into one string.

It would be nice to just delegate this work to `content_tag`, but for non-Rails usage, this rudimentary implementation should work well enough.

This implementation isn't nearly as robust as the one found in the Rails source. I'm unsure if there is any risk involved in just `join`ing the values in the array, so if you have any suggestions to make it more robust, I'm happy to implement them.